### PR TITLE
Fix the published package.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,5 @@
 doc/
 doc_src/
 testReports/
+Jenkinsfile
+webpack.demo.config.js


### PR DESCRIPTION
The published package was using `.gitignore` which ignored the dist folder, as well as permitting some other files that should have been ignored.